### PR TITLE
Fix for negative flakes

### DIFF
--- a/fauxflake-core/src/main/java/com/github/rholder/fauxflake/util/MacUtils.java
+++ b/fauxflake-core/src/main/java/com/github/rholder/fauxflake/util/MacUtils.java
@@ -92,8 +92,15 @@ public abstract class MacUtils {
      * Optionally setting the system property OVERRIDE_MAC_PROP to a valid MAC
      * address will result in it being returned instead.
      */
-    public static byte[] macAddress() {
+public static byte[] macAddress() {
         byte[] override = getOverride();
-        return  override != null ? override : realMacAddress();
+
+        if (override == null)
+            override = realMacAddress();
+
+        // lop off unicast/multicast lower bit to preserve top vendor bit & resolution. This
+        override[0] = (byte)((short)(override[0] & 0xff) >> 1);
+
+        return override;
     }
 }


### PR DESCRIPTION
The top most bit of the first Vendor byte is causing negative MAC
addressed and hence negative flakes. I suggest removing the least
significant bit of first vendor byte, the Multi/uni cast indicator
which would be the same for all PC NICs then shift the remaining 7 bits
down (right) 1.
